### PR TITLE
Revert "soundpool: reuse channel for same sample if available"

### DIFF
--- a/include/media/SoundPool.h
+++ b/include/media/SoundPool.h
@@ -144,7 +144,6 @@ public:
     void nextEvent();
     int nextChannelID() { return mNextEvent.channelID(); }
     void dump();
-    int getPrevSampleID(void) { return mPrevSampleID; }
 
 private:
     static void callback(int event, void* user, void *info);
@@ -161,7 +160,6 @@ private:
     int                 mAudioBufferSize;
     unsigned long       mToggle;
     bool                mAutoPaused;
-    int                 mPrevSampleID;
 };
 
 // application object for managing a pool of sounds
@@ -204,7 +202,7 @@ private:
     sp<Sample> findSample(int sampleID) { return mSamples.valueFor(sampleID); }
     SoundChannel* findChannel (int channelID);
     SoundChannel* findNextChannel (int channelID);
-    SoundChannel* allocateChannel_l(int priority, int sampleID);
+    SoundChannel* allocateChannel_l(int priority);
     void moveToFront_l(SoundChannel* channel);
     void notify(SoundPoolEvent event);
     void dump();

--- a/media/libmedia/SoundPool.cpp
+++ b/media/libmedia/SoundPool.cpp
@@ -262,7 +262,7 @@ int SoundPool::play(int sampleID, float leftVolume, float rightVolume,
     dump();
 
     // allocate a channel
-    channel = allocateChannel_l(priority, sampleID);
+    channel = allocateChannel_l(priority);
 
     // no channel allocated - return 0
     if (!channel) {
@@ -277,25 +277,13 @@ int SoundPool::play(int sampleID, float leftVolume, float rightVolume,
     return channelID;
 }
 
-SoundChannel* SoundPool::allocateChannel_l(int priority, int sampleID)
+SoundChannel* SoundPool::allocateChannel_l(int priority)
 {
     List<SoundChannel*>::iterator iter;
     SoundChannel* channel = NULL;
 
-    // check if channel for given sampleID still available
+    // allocate a channel
     if (!mChannels.empty()) {
-        for (iter = mChannels.begin(); iter != mChannels.end(); ++iter) {
-            if (sampleID == (*iter)->getPrevSampleID() && (*iter)->state() == SoundChannel::IDLE) {
-                channel = *iter;
-                mChannels.erase(iter);
-                ALOGV("Allocated recycled channel for same sampleID");
-                break;
-            }
-        }
-    }
-
-    // allocate any channel
-    if (!channel && !mChannels.empty()) {
         iter = mChannels.begin();
         if (priority >= (*iter)->priority()) {
             channel = *iter;
@@ -563,7 +551,6 @@ error:
 void SoundChannel::init(SoundPool* soundPool)
 {
     mSoundPool = soundPool;
-    mPrevSampleID = -1;
 }
 
 // call with sound pool lock held
@@ -572,7 +559,7 @@ void SoundChannel::play(const sp<Sample>& sample, int nextChannelID, float leftV
 {
     sp<AudioTrack> oldTrack;
     sp<AudioTrack> newTrack;
-    status_t status = NO_ERROR;
+    status_t status;
 
     { // scope for the lock
         Mutex::Autolock lock(&mLock);
@@ -618,42 +605,37 @@ void SoundChannel::play(const sp<Sample>& sample, int nextChannelID, float leftV
         }
 #endif
 
-        if (!mAudioTrack.get() || mPrevSampleID != sample->sampleID()) {
-            // mToggle toggles each time a track is started on a given channel.
-            // The toggle is concatenated with the SoundChannel address and passed to AudioTrack
-            // as callback user data. This enables the detection of callbacks received from the old
-            // audio track while the new one is being started and avoids processing them with
-            // wrong audio audio buffer size  (mAudioBufferSize)
-            unsigned long toggle = mToggle ^ 1;
-            void *userData = (void *)((unsigned long)this | toggle);
-            audio_channel_mask_t channelMask = audio_channel_out_mask_from_count(numChannels);
+        // mToggle toggles each time a track is started on a given channel.
+        // The toggle is concatenated with the SoundChannel address and passed to AudioTrack
+        // as callback user data. This enables the detection of callbacks received from the old
+        // audio track while the new one is being started and avoids processing them with
+        // wrong audio audio buffer size  (mAudioBufferSize)
+        unsigned long toggle = mToggle ^ 1;
+        void *userData = (void *)((unsigned long)this | toggle);
+        audio_channel_mask_t channelMask = audio_channel_out_mask_from_count(numChannels);
 
-            // do not create a new audio track if current track is compatible with sample parameters
+        // do not create a new audio track if current track is compatible with sample parameters
 #ifdef USE_SHARED_MEM_BUFFER
-            newTrack = new AudioTrack(streamType, sampleRate, sample->format(),
+        newTrack = new AudioTrack(streamType, sampleRate, sample->format(),
                 channelMask, sample->getIMemory(), AUDIO_OUTPUT_FLAG_FAST, callback, userData);
 #else
-            newTrack = new AudioTrack(streamType, sampleRate, sample->format(),
+        newTrack = new AudioTrack(streamType, sampleRate, sample->format(),
                 channelMask, frameCount, AUDIO_OUTPUT_FLAG_FAST, callback, userData,
                 bufferFrames);
 #endif
-            oldTrack = mAudioTrack;
-            status = newTrack->initCheck();
-            if (status != NO_ERROR) {
-                ALOGE("Error creating AudioTrack");
-                goto exit;
-            }
-            // From now on, AudioTrack callbacks received with previous toggle value will be ignored.
-            mToggle = toggle;
-            mAudioTrack = newTrack;
-            ALOGV("using new track %p for sample %d", newTrack.get(), sample->sampleID());
-        } else {
-            newTrack = mAudioTrack;
-            ALOGV("reusing track %p for sample %d", mAudioTrack.get(), sample->sampleID());
+        oldTrack = mAudioTrack;
+        status = newTrack->initCheck();
+        if (status != NO_ERROR) {
+            ALOGE("Error creating AudioTrack");
+            goto exit;
         }
+        ALOGV("setVolume %p", newTrack.get());
         newTrack->setVolume(leftVolume, rightVolume);
         newTrack->setLoop(0, frameCount, loop);
 
+        // From now on, AudioTrack callbacks received with previous toggle value will be ignored.
+        mToggle = toggle;
+        mAudioTrack = newTrack;
         mPos = 0;
         mSample = sample;
         mChannelID = nextChannelID;
@@ -795,7 +777,6 @@ bool SoundChannel::doStop_l()
         setVolume_l(0, 0);
         ALOGV("stop");
         mAudioTrack->stop();
-        mPrevSampleID = mSample->sampleID();
         mSample.clear();
         mState = IDLE;
         mPriority = IDLE_PRIORITY;


### PR DESCRIPTION
- Causing issues with touch tones. Randomly loosing them
  altogether, and skipping tones when typing fast on the keyboard.

This reverts commit 1abd0c511a4509074097707945681154900b50de.

Change-Id: Ib1c02f1b30750dc1600371656541b41947e889ab
